### PR TITLE
Fix race condition causing properties to remain unfolded

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,25 @@ There are no settings; it basically just checks if the metadata properties are u
 
 **Especially useful to those who want to keep properties out of the way without hiding them entirely.**
 
-# Known issues / potential improvements
+## Known Issues / Potential Improvements
+
 - Properties don't automatically fold when creating a new note which I believe is useful since you might want to enter some before folding them. Don't hesitate to suggest otherwise if that's how you feel like and I might consider implementing an automatic folding feature setting for new notes.
 
-# Installation
-- Go to Obisidian's settings page.
+## Installation
+
+- Go to Obsidian's settings page.
 - Open Community plugins settings page, click on the Browse button.
 - Search for "Fold Properties By Default" in the search bar and find the plugin with this exact name.
 - Click on the Install button.
+
+---
+
+## Updates
+
+### v1.0.9 - Race Condition Fix
+
+Fixed an issue where properties would remain unfolded on some notes. The `file-open` event fires before the DOM is fully rendered, causing the fold command to fail silently. Now uses `MutationObserver` to wait for DOM readiness, plus:
+
+- Added `layout-change` event handler for tab switches
+- Added `onLayoutReady()` wrapper per Obsidian best practices
+- Added `onunload()` cleanup to prevent memory leaks

--- a/main.ts
+++ b/main.ts
@@ -1,26 +1,90 @@
-import { Plugin } from 'obsidian'
+import { Plugin } from 'obsidian';
 
 declare module 'obsidian' {
 	interface App {
 		commands: {
-			commands: { [commandId: string]: { id: string, name: string, callback: () => void } }
-			executeCommandById(commandId: string): boolean
-		}
+			executeCommandById(commandId: string): boolean;
+		};
 	}
 }
 
+/**
+ * Fold Properties By Default
+ *
+ * Automatically folds frontmatter properties when opening notes.
+ * Uses MutationObserver to handle the race condition where the
+ * 'file-open' event fires before the DOM is fully rendered.
+ */
 export default class FoldPropertiesByDefault extends Plugin {
-	foldProperties() {
-		const currentLeaf = document.querySelector('.workspace-leaf.mod-active')
-		if (currentLeaf) {
-			const propertiesAreFolded = currentLeaf.querySelector('.metadata-container.is-collapsed')
-			if (!propertiesAreFolded) {
-				this.app.commands.executeCommandById('editor:toggle-fold-properties')
+	private observer: MutationObserver | null = null;
+
+	async onload(): Promise<void> {
+		// Wait for layout to be ready before registering events
+		this.app.workspace.onLayoutReady(() => {
+			this.registerEvent(
+				this.app.workspace.on('file-open', () => this.scheduleFold())
+			);
+
+			this.registerEvent(
+				this.app.workspace.on('layout-change', () => this.tryFold())
+			);
+
+			// Fold if a file is already open
+			if (this.app.workspace.getActiveFile()) {
+				this.scheduleFold();
 			}
-		}
+		});
 	}
 
-	async onload() {
-		this.registerEvent(this.app.workspace.on('file-open', this.foldProperties.bind(this)))
+	onunload(): void {
+		this.cleanupObserver();
+	}
+
+	/**
+	 * Schedule a fold operation, waiting for the DOM if necessary.
+	 */
+	private scheduleFold(): void {
+		this.cleanupObserver();
+
+		// Try immediately - DOM might already be ready
+		if (this.tryFold()) return;
+
+		// Otherwise, watch for DOM changes
+		this.observer = new MutationObserver(() => {
+			if (this.tryFold()) {
+				this.cleanupObserver();
+			}
+		});
+
+		this.observer.observe(document.body, { childList: true, subtree: true });
+
+		// Safety timeout to prevent indefinite observation
+		setTimeout(() => this.cleanupObserver(), 2000);
+	}
+
+	/**
+	 * Attempt to fold properties if they exist and aren't already folded.
+	 * @returns true if fold was successful or already folded
+	 */
+	private tryFold(): boolean {
+		const leaf = document.querySelector('.workspace-leaf.mod-active');
+		if (!leaf) return false;
+
+		const container = leaf.querySelector('.metadata-container');
+		if (!container) return false;
+
+		if (container.classList.contains('is-collapsed')) {
+			return true; // Already folded
+		}
+
+		this.app.commands.executeCommandById('editor:toggle-fold-properties');
+		return true;
+	}
+
+	private cleanupObserver(): void {
+		if (this.observer) {
+			this.observer.disconnect();
+			this.observer = null;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes issue where properties remain unfolded on some notes
- The `file-open` event fires before the DOM is rendered, causing the fold command to silently fail
- Uses `MutationObserver` to wait for DOM readiness before folding

## Changes

- **MutationObserver** - Watches for `.metadata-container` to appear before folding
- **`onLayoutReady()`** - Wraps event registration per Obsidian best practices
- **`layout-change` event** - Handles tab switches (not just file opens)
- **`onunload()`** - Proper resource cleanup to prevent memory leaks
- **Safety timeout** - 2-second limit to prevent indefinite observation
- **JSDoc comments** - Documents the approach

## Test plan

- [x] Open existing notes with properties → folds correctly
- [x] Create new notes → folds correctly
- [x] Switch between tabs → folds correctly
- [x] Manual fold/unfold → still works as expected
- [x] Build compiles with no errors
